### PR TITLE
Fix flash attention state accumulation

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2222,8 +2222,8 @@ extern "C" {
     GGML_API void                          ggml_threadpool_params_init   (struct ggml_threadpool_params * p, int n_threads);
     GGML_API bool                          ggml_threadpool_params_match  (const struct ggml_threadpool_params * p0, const struct ggml_threadpool_params * p1);
 
-    // Enhanced flash attention with state tensor for S/M values
-    // s_m_state: [2, n_heads * q_len] tensor containing [M, S] pairs for each head/position
+    // Enhanced flash attention with state tensor for S/M values and accumulated numerator
+    // s_m_state: [2 + head_dim, n_heads * q_len] tensor containing [M, S, VKQ...] for each head/position
     GGML_API struct ggml_tensor * ggml_flash_attn_ext_with_state(
             struct ggml_context * ctx,
             struct ggml_tensor  * q,

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4616,9 +4616,9 @@ struct ggml_tensor * ggml_flash_attn_ext_with_state(
         GGML_ASSERT(mask);
     }
 
-    // Validate state tensor format: [2, n_heads * q_len]
+    // Validate state tensor format: [2 + head_dim, n_heads * q_len]
     GGML_ASSERT(s_m_state != NULL);
-    GGML_ASSERT(s_m_state->ne[0] == 2);  // [M, S] pairs
+    GGML_ASSERT(s_m_state->ne[0] == v->ne[0] + 2);  // [M, S, VKQ...] per head/position
     GGML_ASSERT(s_m_state->ne[1] == q->ne[2] * q->ne[1]);  // n_heads * q_len
     GGML_ASSERT(s_m_state->type == GGML_TYPE_F32);
 


### PR DESCRIPTION
## Summary
- extend flash attention state tensor to store accumulated VKQ values
- adjust ops to read/store full state, keeping numerators across segments
- update API documentation and validation for new state layout
- enhance test to use expanded state tensor and verify exact match

## Testing
- `cmake --build build-x86_64 --config Release -j12`
- `./build-x86_64/bin/test-flash-attn-state`

------
https://chatgpt.com/codex/tasks/task_e_6854917486ac83329eb2492474af1ecc