### PR TITLE
Refactor flash attention workspace handling

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2224,12 +2224,17 @@ extern "C" {
 
     // Enhanced flash attention with state tensor for S/M values
     // s_m_state: [2, n_heads * q_len] tensor containing [M, S] pairs for each head/position
+    // k_quant / v_quant provide optional quantized KV cache segments
+    // qk_mask_quant is the mask corresponding to the quantized KV part
     GGML_API struct ggml_tensor * ggml_flash_attn_ext_with_state(
             struct ggml_context * ctx,
             struct ggml_tensor  * q,
             struct ggml_tensor  * k,
             struct ggml_tensor  * v,
             struct ggml_tensor  * mask,
+            struct ggml_tensor  * k_quant,
+            struct ggml_tensor  * v_quant,
+            struct ggml_tensor  * qk_mask_quant,
             struct ggml_tensor  * s_m_state,  // State tensor for S and M values
             float                 scale,
             float                 max_bias,

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2879,7 +2879,7 @@ struct ggml_cplan ggml_graph_plan(
                             const int64_t ne10 = node->src[1]->ne[0]; // DK
                             const int64_t ne20 = node->src[2]->ne[0]; // DV
 
-                            cur = sizeof(float)*(1*ne10 + 2*ne20)*n_tasks; // 1x head size K + 2x head size V (per thread)
+                            cur = sizeof(float)*(1*ne10 + 2*ne20)*n_tasks;
                         } else if (mode == GGML_PREC_MIXED) {
                             const int64_t N_Q_HEADS = node->src[0]->ne[2];  // n_q_heads
                             const int64_t SEQ_LEN   = node->src[0]->ne[1];  // sequence length
@@ -2896,9 +2896,11 @@ struct ggml_cplan ggml_graph_plan(
                             const int64_t ne10 = node->src[1]->ne[0]; // DK
                             const int64_t ne20 = node->src[2]->ne[0]; // DV
 
-                            cur = sizeof(float)*(1*ne10 + 2*ne20)*n_tasks; // 1x head size K + 2x head size V (per thread)
+                            cur = sizeof(float)*(1*ne10 + 2*ne20)*n_tasks;
                         }
-
+                        const int64_t N_HEAD = node->src[0]->ne[2];
+                        const int64_t Q_LEN  = node->src[0]->ne[1];
+                        cur += sizeof(float) * 2 * N_HEAD * Q_LEN;
 
                     } break;
                 case GGML_OP_FLASH_ATTN_BACK:

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4596,6 +4596,9 @@ struct ggml_tensor * ggml_flash_attn_ext_with_state(
         struct ggml_tensor  * k,
         struct ggml_tensor  * v,
         struct ggml_tensor  * mask,
+        struct ggml_tensor  * k_quant,
+        struct ggml_tensor  * v_quant,
+        struct ggml_tensor  * qk_mask_quant,
         struct ggml_tensor  * s_m_state,
         float                 scale,
         float                 max_bias,
@@ -4634,9 +4637,10 @@ struct ggml_tensor * ggml_flash_attn_ext_with_state(
     result->src[1] = k;
     result->src[2] = v;
     result->src[3] = mask;
-    result->src[4] = NULL;  // k_quant not used in this variant
-    result->src[5] = NULL;  // v_quant not used in this variant
-    result->src[6] = s_m_state;  // State tensor for S and M values
+    result->src[4] = k_quant;
+    result->src[5] = v_quant;
+    result->src[6] = qk_mask_quant;
+    result->src[7] = s_m_state;  // State tensor for S and M values
 
     return result;
 }


### PR DESCRIPTION
## Summary
- manage flash attention state via workspace buffer
- adjust workspace size calculations accordingly
- remove pointer hacks from llama graph and tests

## Testing
- `cmake -G Ninja -D GGML_GRAPH_PROFILER=ON -D GGML_CUDA=OFF -D GGML_TMAC=OFF -D LLAMA_TORCH=ON -B build-x86_64`
- `cmake --build build-x86_64 --config Release -j12`
- `build-x86_64/bin/test-flash-attn-state`

------
https://chatgpt.com/codex/tasks/task_e_685c5413c7748332af0d0512f80f4b57